### PR TITLE
[maint] Make sure keepalive runs on only one workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,5 +102,6 @@ jobs:
     # keepalive-workflow adds a dummy commit if there's no other action here, keeps
     # GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v1
+      if: matrix.ddev_version == 'stable'
 
 


### PR DESCRIPTION
With two workflows, the keepalive-workflow will try to commit twice, but the second one fails, giving ugly errors once a month. This is better.